### PR TITLE
Set repo_server_path default value based on an env var

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -14,9 +14,18 @@ Redmine::Plugin.register :cosmosys_git do
 
   menu :project_menu, :cosmosys_git, {:controller => 'cosmosys_git', :action => 'menu' }, :caption => 'cosmoSysGit', :after => :activity, :param => :id
 
+  def repo_server_path()
+    if ENV["COSMOSYS_GIT_USER"]
+      user = ENV["COSMOSYS_GIT_USER"]
+      "ssh://git@gitlab/#{user}/%project_id%.git"
+    else
+      "ssh://git@gitlab/cosmobots/%project_id%.git"
+    end
+  end
+
   settings :default => {
-    "repo_local_path"=>"/home/redmine/gitbase/csys/%project_id%", 
-    "repo_server_path"=>"ssh://git@gitlab/cosmobots/%project_id%.git",
+    "repo_local_path" => "/home/redmine/gitbase/csys/%project_id%",
+    "repo_server_path" => repo_server_path(),
     "repo_template_id" => "template",
     "repo_redmine_path" => "/home/redmine/gitbase/csys_rm/%project_id%.git",
     "import_path" => "01_importing/csys%project_code%.ods",


### PR DESCRIPTION
**Don't merge yet, look [comment below](https://github.com/cosmoBots/cosmosys_git_rm/pull/3#issuecomment-2054268172).**

If the `COSMOSYS_GIT_USER` environment variable is available, its value must be used to set the correct `repo_server_path` setting to avoid the manual modification of this value when an instance is deployed.

It is tested with the deployment of instances with the new method in which we are working. However, it should not break nothing because:

1. If the `COSMOSYS_GIT_USER` environment variable isn't set, it just return the default value.
2. If an already deployed instance have changed its `repo_server_path`, it is already on the `settings` table of Redmine, so the default value for `repo_server_path` shouldn't affect unless the value in the database would be reset.

If this change is considered a fix, version of this plugin should be bumped to `0.0.3`. If this change is considered a new feature/functionality, the plugin should be bumped to `0.1.0`. Let me know and I will add the version bumping commit to this PR.

Ping: @txinto.